### PR TITLE
Depend on the framework-suggested development toolchain.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
 	],
 
 	install_requires = [
-		'WebCore>=2.0,<3',
+		'WebCore>=2.0,<3', # Web framework.
 		'marrow.mongo', # Database connectivity.
 		'web.dispatch.object', # Object (class-based filesystem-like) dispatch.
 		'web.dispatch.resource', # Resource (RESTful) dispatch.
@@ -62,7 +62,7 @@ setup(
 			'pytest',
 			'pytest-spec',
 			'pytest-flakes',
-			'backlash',  # Web-based interactive REPL shell and traceback explorer.
+			'WebCore[development]>=2.0,<3', # Install additional framework-suggested development tools.
 		],
 	),
 


### PR DESCRIPTION
Instead of pulling in every specific additional dependency, i.e. `backlash`, _and_ `ptipython`, _and_ `pudb`, _and_ …