### PR TITLE
Python 3 namespace packaging changes, updated pinned versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 setup(
 	name = "WebCore-PathOfExile-Site",
 	version = "0.1",
-
+	
 	description = "A clone of the Path of Exile website with forums built in WebCore.",
 	long_description = "",
 	url = "https://github.com/jmpurtle/wc-poe-site",
@@ -20,18 +20,18 @@ setup(
 	author_email = "hello@johnpurtle.com",
 	license = "mit",
 	keywords = [],
-
+	
 	packages = ('web.app.wc_poe_site', ),
 	include_package_data = True,
 	package_data = {'': [
 		'README.rst',
 		'LICENSE.txt'
 	]},
-
+	
 	setup_requires = [
 		'pytest-runner',
 	],
-
+	
 	tests_require = [
 		'pytest-runner',
 		'coverage',
@@ -41,7 +41,7 @@ setup(
 		'pytest-flakes',
 		'backlash', # debug tests
 	],
-
+	
 	install_requires = [
 		'WebCore[development]~=3.0', # Web framework.
 		'web.dispatch.object~=3.0', # Object (class-based filesystem-like) dispatch.
@@ -49,7 +49,7 @@ setup(
 		'marrow.mongo~=2.0', # Database connectivity.
 		'cinje~=1.1.2', # Template engine.
 	],
-
+	
 	extras_require = dict(
 		development = [
 			'pytest-runner',
@@ -59,6 +59,6 @@ setup(
 			'pytest-flakes',
 		],
 	),
-
+	
 	entry_points = {}
 )

--- a/setup.py
+++ b/setup.py
@@ -21,17 +21,12 @@ setup(
 	license = "mit",
 	keywords = [],
 
-	packages = find_packages(exclude=['test', 'example', 'conf', 'benchmark', 'tool', 'doc']),
+	packages = ('web.app.wc_poe_site', ),
 	include_package_data = True,
 	package_data = {'': [
 		'README.rst',
 		'LICENSE.txt'
 	]},
-
-	namespace_packages = [
-		'web', # primary namespace
-		'web.app', # application code goes here
-	],
 
 	setup_requires = [
 		'pytest-runner',
@@ -48,11 +43,11 @@ setup(
 	],
 
 	install_requires = [
-		'WebCore[development]>=2.0,<3', # Web framework.
-		'marrow.mongo', # Database connectivity.
-		'web.dispatch.object', # Object (class-based filesystem-like) dispatch.
-		'web.dispatch.resource', # Resource (RESTful) dispatch.
-		'cinje', # Template engine.
+		'WebCore[development]~=3.0', # Web framework.
+		'web.dispatch.object~=3.0', # Object (class-based filesystem-like) dispatch.
+		'web.dispatch.resource~=3.0', # Resource (RESTful) dispatch.
+		'marrow.mongo~=2.0', # Database connectivity.
+		'cinje~=1.1.2', # Template engine.
 	],
 
 	extras_require = dict(

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/web/app/__init__.py
+++ b/web/app/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover


### PR DESCRIPTION
Web framework dependencies are released, excluding the framework package itself, WebCore, and two utility packages which currently have no formal release, `web.security` and `web.session`.  (Will need to be installed from clone when the time comes, if a release hasn't been rolled yet.)  Additionally, use of `marrow.mongo` now depends on use of a clone of the `next` branch to make use of the updated namespace packaging.

Recommend cloning and installing from clone: (for now)

* `git@github.com:marrow/mongo.git` @ `next`
* `git@github.com:marrow/WebCore.git` @ `develop`
* `git@github.com:marrow/web.security.git` @ `develop`
* `git@github.com:marrow/web.session.git` @ `develop`