### PR TITLE
Cleanup and elimination of custom Path construction.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,6 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
-import os
-
-from setuptools import setup, find_packages
-
-
-here = os.path.abspath(os.path.dirname(__file__))
+from setuptools import setup
 
 
 setup(
@@ -18,7 +12,7 @@ setup(
 	url = "https://github.com/jmpurtle/wc-poe-site",
 	author = "John Purtle",
 	author_email = "hello@johnpurtle.com",
-	license = "mit",
+	license = "MIT",
 	keywords = [],
 	
 	packages = ('web.app.wc_poe_site', ),

--- a/web/app/wc_poe_site/root.py
+++ b/web/app/wc_poe_site/root.py
@@ -1,3 +1,5 @@
+"""Web application initial dispatch point, or "site root"."""
+
 # HTTP status code exception for "302 Found" redirection.
 from webob.exc import HTTPFound
 

--- a/web/app/wc_poe_site/root.py
+++ b/web/app/wc_poe_site/root.py
@@ -1,6 +1,3 @@
-# An easy way to safely combine paths.
-from pathlib import PurePosixPath
-
 # HTTP status code exception for "302 Found" redirection.
 from webob.exc import HTTPFound
 
@@ -14,8 +11,5 @@ class GameAdvert:
 
 	def __call__(self):
 		"""Called to handle direct requests to the web root itself."""
-		
-		# Identify where this application is starting from.
-		path = PurePosixPath(self._ctx.path[-1][1])
 
-		return HTTPFound(location=str(path / 'Game')) # Issue the redirect.
+		return HTTPFound(location=str(self._ctx.path.current / 'Game')) # Issue the redirect.


### PR DESCRIPTION
Ref: https://github.com/marrow/tutorial/commit/d4f9c1f60ea02645f7431a41910a62aee7dc765a

Additionally: like `(object)` declaration of the base class type being no longer required for new classes, neither is per-module encoding declarations (as long as you're using the now-default encoding: `utf-8`.)  We don't/can't use `find_packages` due to the use of namespacing, plus _explicit is better than implicit_.